### PR TITLE
Fix misspelling of EDGE_STRUCT

### DIFF
--- a/index.md
+++ b/index.md
@@ -229,7 +229,7 @@ O(VE)
 
 ```cpp
 pair<int, pair<int, int> > EDGE_STRUCT;
-EDGE_STRUST edges[MAX_E];
+EDGE_STRUCT edges[MAX_E];
 // Algorithm
 for (int i = 1; i <= V; i++) dists[i] = INF;
 dists[source] = 0;


### PR DESCRIPTION
EDGE_STRUCT was misspelled as EDGE_STRUST in the Bellman-Ford algorithm.